### PR TITLE
Add React + Apollo storefront and Magento GraphQL store-config resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@
 /var/package/*
 !/var/package/*.xml
 
+
+# Frontend artifacts
+/frontend/node_modules/
+/frontend/dist/
+/frontend/.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# ANE
+# ANE Magento + React GraphQL Storefront
+
+You're right: this implementation now uses **React JS (react-scripts)** + **GraphQL** + **Magento** only (no Vite tooling).
+
+## What is included
+
+- Magento 2 module: `ANE_ReactGraphQl`
+- React JS storefront with pages for:
+  - Homepage
+  - PLP
+  - PDP
+  - Cart
+  - Checkout
+  - Place order success
+  - Login
+  - Register
+  - My Account
+- Apollo GraphQL integration against Magento GraphQL
+
+## Magento backend setup
+
+Copy `magento/app/code/ANE/ReactGraphQl` into your Magento project and run:
+
+```bash
+bin/magento module:enable ANE_ReactGraphQl
+bin/magento setup:upgrade
+bin/magento cache:flush
+```
+
+## React frontend setup (no Vite)
+
+```bash
+cd frontend
+cp .env.example .env
+```
+
+Set Magento GraphQL URL:
+
+```bash
+REACT_APP_MAGENTO_GRAPHQL_URL=http://magento.local/graphql
+```
+
+Install and start:
+
+```bash
+npm install
+npm start
+```
+
+Frontend runs on `http://localhost:3000`.
+
+## GraphQL coverage
+
+The frontend uses Magento GraphQL for:
+
+- Product browse/details (`products`)
+- Cart (`createEmptyCart`, `addProductsToCart`, `cart`)
+- Customer auth and profile (`generateCustomerToken`, `createCustomerV2`, `customer`)
+- Order placement (`placeOrder`)
+
+> Note: Magento checkout in real projects usually also requires shipping, billing, and payment method mutations before `placeOrder`. This starter focuses on the full page flow and GraphQL wiring against local Magento.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_MAGENTO_GRAPHQL_URL=http://localhost/graphql

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ANE Magento GraphQL Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ane-magento-react-frontend",
+  "private": true,
+  "version": "2.0.0",
+  "dependencies": {
+    "@apollo/client": "^3.11.8",
+    "graphql": "^16.9.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.2",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>ANE Magento React Storefront</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,30 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { Layout } from './components/Layout';
+import { HomePage } from './pages/HomePage';
+import { PlpPage } from './pages/PlpPage';
+import { PdpPage } from './pages/PdpPage';
+import { CartPage } from './pages/CartPage';
+import { CheckoutPage } from './pages/CheckoutPage';
+import { OrderSuccessPage } from './pages/OrderSuccessPage';
+import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
+import { MyAccountPage } from './pages/MyAccountPage';
+
+export function App() {
+  return (
+    <Layout>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/plp" element={<PlpPage />} />
+        <Route path="/pdp/:urlKey" element={<PdpPage />} />
+        <Route path="/cart" element={<CartPage />} />
+        <Route path="/checkout" element={<CheckoutPage />} />
+        <Route path="/order/success" element={<OrderSuccessPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/account" element={<MyAccountPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Layout>
+  );
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,31 @@
+import { Link, NavLink } from 'react-router-dom';
+
+const navItems = [
+  ['/', 'Home'],
+  ['/plp', 'PLP'],
+  ['/cart', 'Cart'],
+  ['/checkout', 'Checkout'],
+  ['/login', 'Login'],
+  ['/register', 'Register'],
+  ['/account', 'My Account'],
+];
+
+export function Layout({ children }) {
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <Link to="/" className="logo">
+          ANE Commerce
+        </Link>
+        <nav>
+          {navItems.map(([to, label]) => (
+            <NavLink key={to} to={to} className={({ isActive }) => (isActive ? 'active' : '')}>
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+      <main className="container">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/StoreConfigCard.jsx
+++ b/frontend/src/components/StoreConfigCard.jsx
@@ -1,0 +1,23 @@
+export function StoreConfigCard({ config }) {
+  const entries = [
+    ['Store name', config.store_name],
+    ['Base URL', config.base_url],
+    ['Secure URL', config.secure_base_url],
+    ['Locale', config.locale],
+    ['Default currency', config.default_currency],
+  ];
+
+  return (
+    <section className="card">
+      <h2>Magento Store Configuration</h2>
+      <dl>
+        {entries.map(([label, value]) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{value || 'Not configured'}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/frontend/src/context/CartContext.jsx
+++ b/frontend/src/context/CartContext.jsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useMutation } from '@apollo/client';
+import { ADD_TO_CART, CREATE_EMPTY_CART } from '../graphql/operations';
+
+const CART_ID_KEY = 'guestCartId';
+
+const CartContext = createContext(null);
+
+export function CartProvider({ children }) {
+  const [createEmptyCart] = useMutation(CREATE_EMPTY_CART);
+  const [addProductsToCart] = useMutation(ADD_TO_CART);
+
+  const ensureCart = async () => {
+    let cartId = window.localStorage.getItem(CART_ID_KEY);
+
+    if (!cartId) {
+      const { data } = await createEmptyCart();
+      cartId = data?.createEmptyCart;
+      if (cartId) {
+        window.localStorage.setItem(CART_ID_KEY, cartId);
+      }
+    }
+
+    return cartId;
+  };
+
+  const addToCart = async (sku, quantity = 1) => {
+    const cartId = await ensureCart();
+    if (!cartId) {
+      throw new Error('Unable to create cart.');
+    }
+
+    await addProductsToCart({
+      variables: {
+        cartId,
+        sku,
+        qty: quantity,
+      },
+    });
+
+    return cartId;
+  };
+
+  const value = useMemo(
+    () => ({
+      addToCart,
+      getCartId: () => window.localStorage.getItem(CART_ID_KEY),
+      clearCartId: () => window.localStorage.removeItem(CART_ID_KEY),
+    }),
+    []
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart() {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error('useCart must be used within CartProvider.');
+  }
+  return context;
+}

--- a/frontend/src/graphql/client.js
+++ b/frontend/src/graphql/client.js
@@ -1,0 +1,22 @@
+import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+
+const graphqlUrl = process.env.REACT_APP_MAGENTO_GRAPHQL_URL || 'http://localhost/graphql';
+
+const httpLink = new HttpLink({ uri: graphqlUrl });
+
+const authLink = setContext((_, { headers }) => {
+  const token = window.localStorage.getItem('customerToken');
+
+  return {
+    headers: {
+      ...headers,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  };
+});
+
+export const client = new ApolloClient({
+  link: authLink.concat(httpLink),
+  cache: new InMemoryCache(),
+});

--- a/frontend/src/graphql/operations.js
+++ b/frontend/src/graphql/operations.js
@@ -1,0 +1,169 @@
+import { gql } from '@apollo/client';
+
+export const GET_STORE_CONFIG = gql`
+  query GetStoreConfig {
+    aneStoreConfig {
+      store_name
+      base_url
+      secure_base_url
+      locale
+      default_currency
+    }
+  }
+`;
+
+export const GET_PRODUCTS = gql`
+  query GetProducts($search: String) {
+    products(search: $search, pageSize: 12) {
+      items {
+        uid
+        sku
+        name
+        url_key
+        small_image {
+          url
+          label
+        }
+        price_range {
+          minimum_price {
+            regular_price {
+              value
+              currency
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GET_PRODUCT_BY_URL_KEY = gql`
+  query GetProductByUrlKey($urlKey: String!) {
+    products(filter: { url_key: { eq: $urlKey } }) {
+      items {
+        uid
+        sku
+        name
+        description {
+          html
+        }
+        small_image {
+          url
+          label
+        }
+        price_range {
+          minimum_price {
+            regular_price {
+              value
+              currency
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const CREATE_EMPTY_CART = gql`
+  mutation CreateEmptyCart {
+    createEmptyCart
+  }
+`;
+
+export const GET_CART = gql`
+  query GetCart($cartId: String!) {
+    cart(cart_id: $cartId) {
+      id
+      total_quantity
+      items {
+        uid
+        quantity
+        product {
+          sku
+          name
+          url_key
+          small_image {
+            url
+          }
+        }
+        prices {
+          row_total {
+            value
+            currency
+          }
+        }
+      }
+      prices {
+        grand_total {
+          value
+          currency
+        }
+      }
+    }
+  }
+`;
+
+export const ADD_TO_CART = gql`
+  mutation AddProductsToCart($cartId: String!, $sku: String!, $qty: Float!) {
+    addProductsToCart(
+      cartId: $cartId
+      cartItems: [{ sku: $sku, quantity: $qty }]
+    ) {
+      cart {
+        id
+      }
+    }
+  }
+`;
+
+export const GENERATE_CUSTOMER_TOKEN = gql`
+  mutation GenerateCustomerToken($email: String!, $password: String!) {
+    generateCustomerToken(email: $email, password: $password) {
+      token
+    }
+  }
+`;
+
+export const CREATE_CUSTOMER = gql`
+  mutation CreateCustomer(
+    $firstname: String!
+    $lastname: String!
+    $email: String!
+    $password: String!
+  ) {
+    createCustomerV2(
+      input: {
+        firstname: $firstname
+        lastname: $lastname
+        email: $email
+        password: $password
+      }
+    ) {
+      customer {
+        firstname
+        lastname
+        email
+      }
+    }
+  }
+`;
+
+export const GET_CUSTOMER = gql`
+  query GetCustomer {
+    customer {
+      firstname
+      lastname
+      email
+    }
+  }
+`;
+
+export const PLACE_ORDER = gql`
+  mutation PlaceOrder($cartId: String!) {
+    placeOrder(input: { cart_id: $cartId }) {
+      orderV2 {
+        number
+      }
+    }
+  }
+`;

--- a/frontend/src/graphql/queries.js
+++ b/frontend/src/graphql/queries.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const GET_ANE_STORE_CONFIG = gql`
+  query GetAneStoreConfig {
+    aneStoreConfig {
+      base_url
+      secure_base_url
+      store_name
+      locale
+      default_currency
+    }
+  }
+`;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ApolloProvider } from '@apollo/client';
+import { BrowserRouter } from 'react-router-dom';
+import { client } from './graphql/client';
+import { CartProvider } from './context/CartContext';
+import { App } from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ApolloProvider client={client}>
+      <BrowserRouter>
+        <CartProvider>
+          <App />
+        </CartProvider>
+      </BrowserRouter>
+    </ApolloProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ApolloProvider } from '@apollo/client';
+import { BrowserRouter } from 'react-router-dom';
+import { client } from './graphql/client';
+import { CartProvider } from './context/CartContext';
+import { App } from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ApolloProvider client={client}>
+      <BrowserRouter>
+        <CartProvider>
+          <App />
+        </CartProvider>
+      </BrowserRouter>
+    </ApolloProvider>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/CartPage.jsx
+++ b/frontend/src/pages/CartPage.jsx
@@ -1,0 +1,44 @@
+import { useQuery } from '@apollo/client';
+import { Link } from 'react-router-dom';
+import { GET_CART } from '../graphql/operations';
+import { useCart } from '../context/CartContext';
+
+export function CartPage() {
+  const { getCartId } = useCart();
+  const cartId = getCartId();
+  const { data, loading } = useQuery(GET_CART, {
+    variables: { cartId: cartId ?? '' },
+    skip: !cartId,
+  });
+
+  if (!cartId) {
+    return (
+      <section>
+        <h1>Cart</h1>
+        <p>Your cart is empty. Start from the <Link to="/plp">PLP</Link>.</p>
+      </section>
+    );
+  }
+
+  const cart = data?.cart;
+
+  return (
+    <section>
+      <h1>Cart</h1>
+      {loading ? <p>Loading cart...</p> : null}
+      {cart?.items?.map((item) => (
+        <article key={item.uid} className="card">
+          <h3>{item.product.name}</h3>
+          <p>Qty: {item.quantity}</p>
+          <p>
+            {item.prices?.row_total?.value} {item.prices?.row_total?.currency}
+          </p>
+        </article>
+      ))}
+      <p>
+        <strong>Total:</strong> {cart?.prices?.grand_total?.value ?? 0} {cart?.prices?.grand_total?.currency ?? ''}
+      </p>
+      <Link to="/checkout">Proceed to checkout</Link>
+    </section>
+  );
+}

--- a/frontend/src/pages/CheckoutPage.jsx
+++ b/frontend/src/pages/CheckoutPage.jsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@apollo/client';
+import { PLACE_ORDER } from '../graphql/operations';
+import { useCart } from '../context/CartContext';
+
+export function CheckoutPage() {
+  const navigate = useNavigate();
+  const { getCartId, clearCartId } = useCart();
+  const [email, setEmail] = useState('');
+  const [address, setAddress] = useState('');
+  const [message, setMessage] = useState('');
+  const [placeOrder] = useMutation(PLACE_ORDER);
+
+  const handlePlaceOrder = async (event) => {
+    event.preventDefault();
+    const cartId = getCartId();
+
+    if (!cartId) {
+      setMessage('No active cart found.');
+      return;
+    }
+
+    try {
+      const { data } = await placeOrder({ variables: { cartId } });
+      const orderNumber = data?.placeOrder?.orderV2?.number;
+      clearCartId();
+      navigate('/order/success', { state: { orderNumber } });
+    } catch (error) {
+      setMessage(error.message);
+    }
+  };
+
+  return (
+    <section>
+      <h1>Checkout</h1>
+      <p>Fill required details and place your order.</p>
+      <form className="stack" onSubmit={handlePlaceOrder}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <textarea
+          placeholder="Shipping address"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          required
+        />
+        <button type="submit">Place order</button>
+      </form>
+      {message ? <p className="notice error">{message}</p> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { GET_STORE_CONFIG } from '../graphql/operations';
+
+export function HomePage() {
+  const { data } = useQuery(GET_STORE_CONFIG);
+  const config = data?.aneStoreConfig;
+
+  return (
+    <section>
+      <h1>Magento + React Storefront</h1>
+      <p>Starter storefront connected to your local Magento GraphQL backend.</p>
+      <div className="grid two-up">
+        <article className="card">
+          <h2>Store details</h2>
+          <p><strong>Name:</strong> {config?.store_name ?? 'N/A'}</p>
+          <p><strong>Locale:</strong> {config?.locale ?? 'N/A'}</p>
+          <p><strong>Currency:</strong> {config?.default_currency ?? 'N/A'}</p>
+        </article>
+        <article className="card">
+          <h2>Quick start</h2>
+          <ul>
+            <li><Link to="/plp">Browse products (PLP)</Link></li>
+            <li><Link to="/cart">Review cart</Link></li>
+            <li><Link to="/checkout">Checkout</Link></li>
+            <li><Link to="/account">My account</Link></li>
+          </ul>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { GENERATE_CUSTOMER_TOKEN } from '../graphql/operations';
+
+export function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const [generateCustomerToken] = useMutation(GENERATE_CUSTOMER_TOKEN);
+  const navigate = useNavigate();
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      const { data } = await generateCustomerToken({ variables: { email, password } });
+      const token = data?.generateCustomerToken?.token;
+      if (token) {
+        window.localStorage.setItem('customerToken', token);
+        navigate('/account');
+      }
+    } catch (error) {
+      setMessage(error.message);
+    }
+  };
+
+  return (
+    <section>
+      <h1>Login</h1>
+      <form className="stack" onSubmit={onSubmit}>
+        <input type="email" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <input type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <button type="submit">Login</button>
+      </form>
+      {message ? <p className="notice error">{message}</p> : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/MyAccountPage.jsx
+++ b/frontend/src/pages/MyAccountPage.jsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { GET_CUSTOMER } from '../graphql/operations';
+
+export function MyAccountPage() {
+  const navigate = useNavigate();
+  const token = window.localStorage.getItem('customerToken');
+  const { data, loading, error } = useQuery(GET_CUSTOMER, { skip: !token });
+
+  if (!token) {
+    return (
+      <section>
+        <h1>My Account</h1>
+        <p>Please login first.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <h1>My Account</h1>
+      {loading ? <p>Loading customer details...</p> : null}
+      {error ? <p className="notice error">{error.message}</p> : null}
+      {data?.customer ? (
+        <article className="card">
+          <p><strong>Name:</strong> {data.customer.firstname} {data.customer.lastname}</p>
+          <p><strong>Email:</strong> {data.customer.email}</p>
+          <button
+            onClick={() => {
+              window.localStorage.removeItem('customerToken');
+              navigate('/login');
+            }}
+          >
+            Logout
+          </button>
+        </article>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/pages/OrderSuccessPage.jsx
+++ b/frontend/src/pages/OrderSuccessPage.jsx
@@ -1,0 +1,17 @@
+import { Link, useLocation } from 'react-router-dom';
+
+export function OrderSuccessPage() {
+  const { state } = useLocation();
+  const orderNumber = state?.orderNumber;
+
+  return (
+    <section>
+      <h1>Order placed</h1>
+      <p>Your order has been placed successfully.</p>
+      <p>
+        <strong>Order #:</strong> {orderNumber ?? 'N/A'}
+      </p>
+      <Link to="/">Back to home</Link>
+    </section>
+  );
+}

--- a/frontend/src/pages/PdpPage.jsx
+++ b/frontend/src/pages/PdpPage.jsx
@@ -1,0 +1,32 @@
+import { useQuery } from '@apollo/client';
+import { useParams } from 'react-router-dom';
+import { GET_PRODUCT_BY_URL_KEY } from '../graphql/operations';
+import { useCart } from '../context/CartContext';
+
+export function PdpPage() {
+  const { urlKey } = useParams();
+  const { addToCart } = useCart();
+  const { data, loading } = useQuery(GET_PRODUCT_BY_URL_KEY, { variables: { urlKey } });
+
+  const product = data?.products?.items?.[0];
+
+  if (loading) return <p>Loading product...</p>;
+  if (!product) return <p>Product not found.</p>;
+
+  return (
+    <section>
+      <h1>Product Detail (PDP)</h1>
+      <article className="card">
+        <h2>{product.name}</h2>
+        <p>
+          {product.price_range?.minimum_price?.regular_price?.value}{' '}
+          {product.price_range?.minimum_price?.regular_price?.currency}
+        </p>
+        <div dangerouslySetInnerHTML={{ __html: product.description?.html ?? '' }} />
+        <button type="button" onClick={() => addToCart(product.sku, 1)}>
+          Add to cart
+        </button>
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/pages/PlpPage.jsx
+++ b/frontend/src/pages/PlpPage.jsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import { GET_PRODUCTS } from '../graphql/operations';
+import { useCart } from '../context/CartContext';
+
+export function PlpPage() {
+  const [search, setSearch] = useState('');
+  const [notice, setNotice] = useState('');
+  const { data, loading, refetch } = useQuery(GET_PRODUCTS, { variables: { search: '' } });
+  const { addToCart } = useCart();
+
+  const products = data?.products?.items ?? [];
+
+  const onSearch = async (event) => {
+    event.preventDefault();
+    await refetch({ search });
+  };
+
+  return (
+    <section>
+      <h1>Product Listing (PLP)</h1>
+      <form className="row" onSubmit={onSearch}>
+        <input value={search} onChange={(e) => setSearch(e.target.value)} placeholder="Search products" />
+        <button type="submit">Search</button>
+      </form>
+      {notice && <p className="notice">{notice}</p>}
+      {loading ? <p>Loading...</p> : null}
+      <div className="grid cards">
+        {products.map((product) => (
+          <article key={product.uid} className="card product-card">
+            <h3>{product.name}</h3>
+            <p>{product.price_range?.minimum_price?.regular_price?.value} {product.price_range?.minimum_price?.regular_price?.currency}</p>
+            <div className="row">
+              <Link to={`/pdp/${product.url_key}`}>View PDP</Link>
+              <button
+                type="button"
+                onClick={async () => {
+                  await addToCart(product.sku, 1);
+                  setNotice(`${product.name} added to cart.`);
+                }}
+              >
+                Add to cart
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { useNavigate } from 'react-router-dom';
+import { CREATE_CUSTOMER } from '../graphql/operations';
+
+export function RegisterPage() {
+  const [form, setForm] = useState({ firstname: '', lastname: '', email: '', password: '' });
+  const [message, setMessage] = useState('');
+  const [createCustomer] = useMutation(CREATE_CUSTOMER);
+  const navigate = useNavigate();
+
+  const onChange = (event) => {
+    setForm((prev) => ({ ...prev, [event.target.name]: event.target.value }));
+  };
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      await createCustomer({ variables: form });
+      setMessage('Account created. Please log in.');
+      setTimeout(() => navigate('/login'), 800);
+    } catch (error) {
+      setMessage(error.message);
+    }
+  };
+
+  return (
+    <section>
+      <h1>Register</h1>
+      <form className="stack" onSubmit={onSubmit}>
+        <input name="firstname" placeholder="First name" value={form.firstname} onChange={onChange} required />
+        <input name="lastname" placeholder="Last name" value={form.lastname} onChange={onChange} required />
+        <input name="email" type="email" placeholder="Email" value={form.email} onChange={onChange} required />
+        <input name="password" type="password" placeholder="Password" value={form.password} onChange={onChange} required />
+        <button type="submit">Create account</button>
+      </form>
+      {message ? <p className="notice">{message}</p> : null}
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,68 @@
+:root {
+  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  color: #111827;
+  background: #f5f7fb;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; }
+a { color: #2563eb; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.app-shell { min-height: 100vh; }
+.topbar {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: #0f172a;
+  color: #fff;
+}
+.logo { color: #fff; font-weight: 700; }
+.topbar nav { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.topbar nav a { color: #bfdbfe; }
+.topbar nav a.active { color: #fff; border-bottom: 1px solid #fff; }
+
+.container { max-width: 1100px; margin: 1.5rem auto; padding: 0 1rem 2rem; }
+
+.grid { display: grid; gap: 1rem; }
+.two-up { grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); }
+.cards { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  padding: 1rem;
+}
+
+.row { display: flex; gap: 0.6rem; align-items: center; flex-wrap: wrap; }
+.stack { display: grid; gap: 0.7rem; max-width: 520px; }
+
+input, textarea {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+  font: inherit;
+}
+
+button {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 8px;
+  padding: 0.55rem 0.85rem;
+  cursor: pointer;
+}
+
+.notice {
+  background: #dcfce7;
+  color: #166534;
+  padding: 0.65rem;
+  border-radius: 8px;
+}
+.notice.error { background: #fee2e2; color: #991b1b; }
+.product-card h3 { margin-top: 0; }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,2 @@
+// Deprecated: this repository now runs with react-scripts (CRA) and does not use this file.
+export default {};

--- a/magento/app/code/ANE/ReactGraphQl/Model/Resolver/StoreConfig.php
+++ b/magento/app/code/ANE/ReactGraphQl/Model/Resolver/StoreConfig.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ANE\ReactGraphQl\Model\Resolver;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Exception\GraphQlInputException;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Model\ScopeInterface;
+
+class StoreConfig implements ResolverInterface
+{
+    public function __construct(
+        private readonly ScopeConfigInterface $scopeConfig
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $value
+     * @param array<string, mixed>|null $args
+     * @return array<string, string|null>
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        ?array $value = null,
+        ?array $args = null
+    ): array {
+        if ($context === null) {
+            throw new GraphQlInputException(__('GraphQL context is required.'));
+        }
+
+        return [
+            'base_url' => $this->scopeConfig->getValue('web/unsecure/base_url', ScopeInterface::SCOPE_STORE),
+            'secure_base_url' => $this->scopeConfig->getValue('web/secure/base_url', ScopeInterface::SCOPE_STORE),
+            'store_name' => $this->scopeConfig->getValue('general/store_information/name', ScopeInterface::SCOPE_STORE),
+            'locale' => $this->scopeConfig->getValue('general/locale/code', ScopeInterface::SCOPE_STORE),
+            'default_currency' => $this->scopeConfig->getValue('currency/options/default', ScopeInterface::SCOPE_STORE),
+        ];
+    }
+}

--- a/magento/app/code/ANE/ReactGraphQl/etc/graphql/schema.graphqls
+++ b/magento/app/code/ANE/ReactGraphQl/etc/graphql/schema.graphqls
@@ -1,0 +1,11 @@
+type Query {
+  aneStoreConfig: AneStoreConfig @resolver(class: "ANE\\ReactGraphQl\\Model\\Resolver\\StoreConfig")
+}
+
+type AneStoreConfig {
+  base_url: String
+  secure_base_url: String
+  store_name: String
+  locale: String
+  default_currency: String
+}

--- a/magento/app/code/ANE/ReactGraphQl/etc/module.xml
+++ b/magento/app/code/ANE/ReactGraphQl/etc/module.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="ANE_ReactGraphQl" setup_version="1.0.0"/>
+</config>

--- a/magento/app/code/ANE/ReactGraphQl/registration.php
+++ b/magento/app/code/ANE/ReactGraphQl/registration.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'ANE_ReactGraphQl',
+    __DIR__
+);


### PR DESCRIPTION
### Motivation

- Provide a lightweight React storefront that talks to Magento via GraphQL and demonstrates a full page flow (PLP, PDP, cart, checkout, account).
- Expose basic Magento store configuration over GraphQL so the React frontend can show store details via an `aneStoreConfig` query.
- Standardize frontend tooling on Create React App (`react-scripts`) and ignore build/artifact folders in `.gitignore`.

### Description

- Add a new React frontend under `frontend/` with `package.json`, pages, components, global styles, `ApolloClient` setup at `frontend/src/graphql/client.js`, and GraphQL operations at `frontend/src/graphql/operations.js` and `queries.js`.
- Implement cart context `CartContext` with mutations for `createEmptyCart` and `addProductsToCart`, and wire pages for PLP, PDP, Cart, Checkout, Login, Register, My Account, and Order success; add `.env.example` and CRA entry files (`index.html`, `public/index.html`, `main.jsx`).
- Add a Magento 2 module `ANE_ReactGraphQl` that registers a new GraphQL query `aneStoreConfig` with schema at `etc/graphql/schema.graphqls` and a resolver implementation at `Model/Resolver/StoreConfig.php` which reads store config values via `ScopeConfigInterface`.
- Update `README.md` with quickstart and GraphQL coverage, add a small `vite.config.js` noting deprecation, and update `.gitignore` to exclude frontend artifacts (`/frontend/node_modules/`, `/frontend/dist/`, `/frontend/.env`).

### Testing

- No automated tests were executed as part of this change.
- The frontend includes a test script via `react-scripts` (`npm test`) but it was not run in this rollout.
- Basic local manual startup instructions were added to `README.md` for smoke testing the frontend and Magento module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16a08ca508327908584e9d79f000f)